### PR TITLE
npm config tmp should have precedence over /tmp

### DIFF
--- a/script/phantomjs/install.js
+++ b/script/phantomjs/install.js
@@ -84,8 +84,8 @@ npmconf.load(function(err, conf) {
 function findSuitableTempDirectory(npmConf) {
   var now = Date.now()
   var candidateTmpDirs = [
-    process.env.TMPDIR || '/tmp',
-    npmConf.get('tmp'),
+    process.env.TMPDIR || npmConf.get('tmp'),
+    '/tmp',
     path.join(process.cwd(), 'tmp')
   ]
 


### PR DESCRIPTION
Previously /tmp would always be tried before `npmConf.get('tmp')`
